### PR TITLE
fix crash when loading recipes which are half-empty

### DIFF
--- a/src/main/java/thelm/packagedexcrafting/recipe/AdvancedPackageRecipeInfo.java
+++ b/src/main/java/thelm/packagedexcrafting/recipe/AdvancedPackageRecipeInfo.java
@@ -159,7 +159,7 @@ public class AdvancedPackageRecipeInfo implements ITablePackageRecipeInfo {
 	public Int2ObjectMap<ItemStack> getEncoderStacks() {
 		Int2ObjectMap<ItemStack> map = new Int2ObjectOpenHashMap<>();
 		int[] slotArray = AdvancedPackageRecipeType.SLOTS.toIntArray();
-		for(int i = 0; i < 25; ++i) {
+		for(int i = 0; i < getMatrixHeight() * getMatrixWidth(); ++i) {
 			map.put(slotArray[i], matrix.getItem(i));
 		}
 		return map;

--- a/src/main/java/thelm/packagedexcrafting/recipe/BasicPackageRecipeInfo.java
+++ b/src/main/java/thelm/packagedexcrafting/recipe/BasicPackageRecipeInfo.java
@@ -159,7 +159,7 @@ public class BasicPackageRecipeInfo implements ITablePackageRecipeInfo {
 	public Int2ObjectMap<ItemStack> getEncoderStacks() {
 		Int2ObjectMap<ItemStack> map = new Int2ObjectOpenHashMap<>();
 		int[] slotArray = BasicPackageRecipeType.SLOTS.toIntArray();
-		for(int i = 0; i < 9; ++i) {
+		for(int i = 0; i < getMatrixHeight() * getMatrixWidth(); ++i) {
 			map.put(slotArray[i], matrix.getItem(i));
 		}
 		return map;

--- a/src/main/java/thelm/packagedexcrafting/recipe/ElitePackageRecipeInfo.java
+++ b/src/main/java/thelm/packagedexcrafting/recipe/ElitePackageRecipeInfo.java
@@ -159,7 +159,7 @@ public class ElitePackageRecipeInfo implements ITablePackageRecipeInfo {
 	public Int2ObjectMap<ItemStack> getEncoderStacks() {
 		Int2ObjectMap<ItemStack> map = new Int2ObjectOpenHashMap<>();
 		int[] slotArray = ElitePackageRecipeType.SLOTS.toIntArray();
-		for(int i = 0; i < 49; ++i) {
+		for(int i = 0; i < getMatrixHeight() * getMatrixWidth() ; ++i) {
 			map.put(slotArray[i], matrix.getItem(i));
 		}
 		return map;

--- a/src/main/java/thelm/packagedexcrafting/recipe/UltimatePackageRecipeInfo.java
+++ b/src/main/java/thelm/packagedexcrafting/recipe/UltimatePackageRecipeInfo.java
@@ -158,7 +158,7 @@ public class UltimatePackageRecipeInfo implements ITablePackageRecipeInfo {
 	@Override
 	public Int2ObjectMap<ItemStack> getEncoderStacks() {
 		Int2ObjectMap<ItemStack> map = new Int2ObjectOpenHashMap<>();
-		for(int i = 0; i < 81; ++i) {
+		for(int i = 0; i < getMatrixHeight() * getMatrixWidth(); ++i) {
 			map.put(i, matrix.getItem(i));
 		}
 		return map;


### PR DESCRIPTION
the getEncoderStacks method assumed that the matrix was always of the maximum possible size.